### PR TITLE
Readd BepInEx 6 to mod loader list

### DIFF
--- a/modinfo.json
+++ b/modinfo.json
@@ -1,5 +1,4 @@
 [
- 
   {
     "name": "MelonLoader",
     "author": "LavaGang",
@@ -7,6 +6,14 @@
     "git_path": "LavaGang/MelonLoader",
     "group": "Core",
     "download_url": "https://github.com/LavaGang/MelonLoader/releases/download/v0.6.6/MelonLoader.x64.zip"
+  },
+  {
+    "name": "BepInEx 6 (Low Compatability)",
+    "author": "BepInEx Team",
+    "version": "v6.0.0-pre-2",
+    "git_path": "BepInEx/BepInEx",
+    "group": "Core",
+    "download_url": "https://github.com/BepInEx/BepInEx/releases/download/v6.0.0-pre.2/BepInEx-Unity.IL2CPP-win-x64-6.0.0-pre.2.zip"
   },
   {
     "name": "Utilla",


### PR DESCRIPTION
BepInEx 6 does work with Capuchin, but nobody actually read the docs and just assumed it didn't work because BepInEx 5 syntax did not work.

This adds BepInEx 6.0.0-pre-2 support back, and I will re-add the BepInEx installer to BMM later.